### PR TITLE
Rename padicfoo to padic_foo in code and document

### DIFF
--- a/padics-doc.tex
+++ b/padics-doc.tex
@@ -92,31 +92,31 @@ the system directory (you will need root permissions for that) \texttt{/usr/shar
 
 \section{The $p-$adic norm}\label{sec2}
 
-We can compute the p-adic order of a rational number with \texttt{padicorder}.
+We can compute the p-adic order of a rational number with \texttt{padic\_order}.
 The syntax of all the commands in the package is quite intuitive; for example,
-to compute the order of a rational with respect to the prime $p$, we use \texttt{padicorder(rational,prime)}:
+to compute the order of a rational with respect to the prime $p$, we use \texttt{padic\_order(rational,prime)}:
 
 \begin{verbatim}
-(%i2)	padicorder(144,3);
+(%i2)	padic_order(144,3);
 (%o2)	2
-(%i3)	padicorder(17,3);
+(%i3)	padic_order(17,3);
 (%o3)	0
 \end{verbatim}
 
 We follow the convention that the order of $0$ is always (real) infinity:
 
 \begin{verbatim}
-(%i4)	makelist(padicorder(0,i),i,[2,3,5,7,11,13]);
+(%i4)	makelist(padic_order(0,i),i,[2,3,5,7,11,13]);
 (%o4)	[inf,inf,inf,inf,inf,inf]
-(%i5)	padicorder(3/10,5);
+(%i5)	padic_order(3/10,5);
 (%o5)	-1
-(%i6)	padicorder(36015/88,7);
+(%i6)	padic_order(36015/88,7);
 (%o6)	4
 \end{verbatim}
 
 Notice that the $p-$adic order is an even function:
 \begin{verbatim}
-(%i7)	padicorder(-3/10,5);
+(%i7)	padic_order(-3/10,5);
 (%o7)	-1
 \end{verbatim}
 
@@ -124,82 +124,82 @@ The reduction to the canonical form of a rational number
 $$
 r=\frac{a}{b}=p^{\mathrm{porder}(r)} \frac{a'}{b'}
 $$
-can be achieved with \texttt{padiccan}. The result has the form of a list 
+can be achieved with \texttt{padic\_canonical}. The result has the form of a list 
 \texttt{[p\^{}porder(r),a'/b']}:
 \begin{verbatim}
-(%i8)	padiccan(0.234,2);
+(%i8)	padic_canonical(0.234,2);
 (%o8)	[1/4,117/125]
-(%i9)	padiccan(0,3);
+(%i9)	padic_canonical(0,3);
 (%o9)	[1,0]
 \end{verbatim}
 
-The $p-$adic norm of a rational number is computed by \texttt{padicnorm}:
+The $p-$adic norm of a rational number is computed by \texttt{padic\_norm}:
 \begin{verbatim}
-(%i10)	makelist(padicnorm(0,j),j,[2,3,5,7,11,13,17]);
+(%i10)	makelist(padic_norm(0,j),j,[2,3,5,7,11,13,17]);
 (%o10)	[0,0,0,0,0,0,0]
-(%i11)	padicnorm(17,17);
+(%i11)	padic_norm(17,17);
 (%o11)	1/17
-(%i12)	padicnorm(144,3);
+(%i12)	padic_norm(144,3);
 (%o12)	1/9
-(%i13)	padicnorm(12,5);
+(%i13)	padic_norm(12,5);
 (%o13)	1
-(%i14)	makelist(padicnorm(162/13,k),k,[3,13]);
+(%i14)	makelist(padic_norm(162/13,k),k,[3,13]);
 (%o14)	[1/81,13]
 \end{verbatim}
 
 The next example comes from \url{http://mathworld.wolfram.com/p-adicNorm.html}:
 \begin{verbatim}
-(%i15)	makelist(padicnorm(140/297,k),k,[2,3,5,7,11]);
+(%i15)	makelist(padic_norm(140/297,k),k,[2,3,5,7,11]);
 (%o15)	[1/4,27,1/5,1/7,11]
 \end{verbatim}
 
 Another example, this one from \url{www.asiapacific-mathnews.com/03/0304/0001_0006.pdf}:
 \begin{verbatim}
-(%i16)	makelist(padicnorm(63/550,k),k,[2,3,5,7,11,13]);
+(%i16)	makelist(padic_norm(63/550,k),k,[2,3,5,7,11,13]);
 (%o16)	[2,1/9,25,1/7,11,1]
-(%i17)	padicnorm(0.234,2);
+(%i17)	padic_norm(0.234,2);
 (%o17)	4
 \end{verbatim}
 
 Let us check the triangle \emph{equality}:
 \begin{verbatim}
-(%i18)	padicnorm(3/10,5);
+(%i18)	padic_norm(3/10,5);
 (%o18)	5
-(%i19)	padicnorm(40,5);
+(%i19)	padic_norm(40,5);
 (%o19)	1/5
-(%i20)	padicnorm(3/10-40,5);
+(%i20)	padic_norm(3/10-40,5);
 (%o20)	5
 \end{verbatim}
 
 The next examples come from \url{https://www.sangakoo.com/en/unit/p-adic-distance}:
 \begin{verbatim}
-(%i21)	padicnorm(10/12,2);
+(%i21)	padic_norm(10/12,2);
 (%o21)	2
-(%i22)	padicnorm(10/12,5);
+(%i22)	padic_norm(10/12,5);
 (%o22)	1/5
-(%i23)	padicnorm(10/12,7);
+(%i23)	padic_norm(10/12,7);
 (%o23)	1
 \end{verbatim}
 
 Of course, once we have a norm available, we can define the
-associated $p-$adic distance, here denoted \texttt{padicdist}.
+associated $p-$adic distance, here denoted \texttt{padic\_distance}.
 The first example computes the distance between $2$ and $28814$ in
 $\mathbb{Q}_7$ (so you can easily guess the syntax):
 	
 \begin{verbatim}
-(%i24)	padicdist(2,28814,7);
+(%i24)	padic_distance(2,28814,7);
 (%o24)	1/2401
-(%i25)	padicdist(2,3,7);
+(%i25)	padic_distance(2,3,7);
 (%o25)	1
-(%i26)	padicdist(2166^2,2,7);
+(%i26)	padic_distance(2166^2,2,7);
 (%o26)	1/2401
-(%i27)	padicdist(3,3+29^4,29);
+(%i27)	padic_distance(3,3+29^4,29);
 (%o27)	1/707281
 \end{verbatim}
 The next example comes from \url{https://www.sangakoo.com/en/unit/p-adic-distance}:
 
 \begin{verbatim}
-(%i28)	padicdist(82,1,3);
+(%i28)	padic_distance(82,1,3);
 (%o28)	1/81
 \end{verbatim}
 
@@ -314,9 +314,9 @@ Let us compare this with the table presented in \cite{2}:
 
 \noindent The basic arithmetic functions are implemented as:
 \begin{itemize}
-	\item  \texttt{padicsum} (for sum, addition)
-	\item  \texttt{padicsubstract} (for difference, substraction)
-	\item  \texttt{padicmult} (for product, multiplication)
+	\item  \texttt{padic\_sum} (for sum, addition)
+	\item  \texttt{padic\_subtract} (for difference, substraction)
+	\item  \texttt{padic\_multiply} (for product, multiplication)
 	\item  \texttt{padivdiv} (for division, quotient)
 \end{itemize}
 
@@ -328,7 +328,7 @@ Some test numbers:
 (l1)	[[-1],4,2,2,2]
 (%i56)	l2:hensel(1/2,5,4);
 (l2)	[[0],3,2,2,2]
-(%i57)	padicsum(l1,l2,5);
+(%i57)	padic_sum(l1,l2,5);
 (%o57)	[[-1],4,0,0,0]
 \end{verbatim}
 
@@ -341,7 +341,7 @@ Notice that the Hensel code for the sum $3/10+1/2$ corresponds to $4/5$:
 Also, notice that a consequence of using a finite segment representation is that
 adding up a really small number with a really big one just gives the bigger:
 \begin{verbatim}
-(%i59)	padicsum([[2],2,5,1,5],[[-3],3,3,3,2],7);
+(%i59)	padic_sum([[2],2,5,1,5],[[-3],3,3,3,2],7);
 (%o59)	[[-3],3,3,3,2]
 \end{verbatim}
 
@@ -351,19 +351,19 @@ Another test (this is an example in \cite{2}) with $p=5$ and $r=9$
 (h1)	[[0],4,1,3,1,3,1,3,1,3]
 (%i61)	h2:hensel(5/6,5,9);
 (h2)	[[1],1,4,0,4,0,4,0,4,0]
-(%i62)	padicsum(h1,h2,5);
+(%i62)	padic_sum(h1,h2,5);
 (%o62)	[[0],4,2,2,2,2,2,2,2,2]
 \end{verbatim}
 
 Let us check the following example in \cite{2}:
 \begin{verbatim}
-(%i63)	padicsubstract(h1,h2,5);
+(%i63)	padic_subtract(h1,h2,5);
 (%o63)	[[0],4,0,4,0,4,0,4,0,4]
 \end{verbatim}
 
 And those of \cite{3}:
 \begin{verbatim}
-(%i64)	padicsubstract(hensel(3/4,5,4),hensel(3/2,5,4),5);
+(%i64)	padic_subtract(hensel(3/4,5,4),hensel(3/2,5,4),5);
 (%o64)	[[0],3,3,3,3]
 \end{verbatim}
 
@@ -373,13 +373,13 @@ An example on multiplication, also from \cite{3}:
 (t1)	[[-1],3,3,1,3]
 (%i66)	t2:hensel(5/2,5,4);
 (t2)	[[1],3,2,2,2]
-(%i67)	padicmult(t1,t2,5);
+(%i67)	padic_multiply(t1,t2,5);
 (%o67)	[[0],4,1,3,1]
 \end{verbatim}
 
 Another example from \cite{2}:
 \begin{verbatim}
-(%i68)	padicmult(h1,h2,5);
+(%i68)	padic_multiply(h1,h2,5);
 (%o68)	[[1],4,2,0,1,2,4,3,2,0]
 \end{verbatim}
 
@@ -389,20 +389,20 @@ An example from \cite{4}:
 (al)	[[0],4,3,3,3]
 (%i70)	be:hensel(1/3,5,4);
 (be)	[[0],2,3,1,3]
-(%i71)	padicmult(al,be,5);
+(%i71)	padic_multiply(al,be,5);
 (%o71)	[[0],3,4,2,4]
 \end{verbatim}
 
-The function normalhensel normalizes the Hensel code so that the
+The function \texttt{normalize\_hensel} normalizes the Hensel code so that the
 first digit after the dot is not zero:
 \begin{verbatim}
-(%i72)	normalhensel([[-1],0,0,1,2,3]);
+(%i72)	normalize_hensel([[-1],0,0,1,2,3]);
 (%o72)	[[1],1,2,3]
 \end{verbatim}
 It is internally used by the function for computing divisions. Our first
 example is a trivial one:
 \begin{verbatim}
-(%i73)	padicdiv([[0],4,0,0,0,0,0,0],[[0],2,0,0,0,0,0,0],7);
+(%i73)	padic_divide([[0],4,0,0,0,0,0,0],[[0],2,0,0,0,0,0,0],7);
 (%o73)	[[0],2,0,0,0,0,0,0]
 \end{verbatim}
 
@@ -412,22 +412,22 @@ The next example is from \cite{2}:
 (dividend)	[[0],4,1,3,1,3,1,3]
 (%i75)	divisor:[[0],3,4,2,4,2,4,2];
 (divisor)	[[0],3,4,2,4,2,4,2]
-(%i76)	padicdivi(dividend,divisor,5);
+(%i76)	padic_dividei(dividend,divisor,5);
 (%o76)	[[0],3,1,0,0,0,0,0]
 (%i77)	d1:[[0],2,1,1,1];
 (d1)	[[0],2,1,1,1]
 (%i78)	d2:[[-1],1,1,0,0];
 (d2)	[[-1],1,1,0,0]
-(%i79)	padicdiv(d1,d2,5);
+(%i79)	padic_divide(d1,d2,5);
 (%o79)	[[1],2,4,1,4]
-(%i80)	padicdiv([[0],4,3,3,3],[[0],0,1,4,0],5);
+(%i80)	padic_divide([[0],4,3,3,3],[[0],0,1,4,0],5);
 (%o80)	[[-2],0,4,2,2]
 \end{verbatim}
 
 This is the example presented in \cite{3}: $1/4/(1/2+1/3)+1/25$
 \begin{verbatim}
-(%i81)	padicsum(padicdiv([[0],4,3,3,3],
-                          padicsum([[0],3,2,2,2],[[0],2,3,1,3],5)
+(%i81)	padic_sum(padic_divide([[0],4,3,3,3],
+                          padic_sum([[0],3,2,2,2],[[0],2,3,1,3],5)
                           ,5),
                  [[-2],1,0,0,0],
                  5);
@@ -448,7 +448,7 @@ Another example, from \cite{4}:
 (alf)	[[0],2,2,4,3]
 (%i85)	bet:hensel(1/2,5,4);
 (bet)	[[0],3,2,2,2]
-(%i86)	padicdiv(alf,bet,5);
+(%i86)	padic_divide(alf,bet,5);
 (%o86)	[[0],4,4,3,2]
 \end{verbatim}
 
@@ -490,39 +490,39 @@ For instance, cases such as
 \texttt{[[m],a0,a1,...,ak,0,0,...,0s]}
 with $s>k$.
 
-The syntax is \texttt{henseltofarey(list,p)}, where \texttt{list} is
+The syntax is \texttt{hensel\_to\_farey(list,p)}, where \texttt{list} is
 a Hensel code, and $p$ is the prime we are considering.
 Some trivial examples:
 \begin{verbatim}
-(%i91)	henseltofarey([[2],3,0,0,0,0,0,0,0],7);
+(%i91)	hensel_to_farey([[2],3,0,0,0,0,0,0,0],7);
 (%o91)	147
-(%i92)	henseltofarey([[0],4,4,4,4,4,4,4],5);
+(%i92)	hensel_to_farey([[0],4,4,4,4,4,4,4],5);
 (%o92)	-1
-(%i93)	henseltofarey([[0],3,3,3,3,3,3,3],5);
+(%i93)	hensel_to_farey([[0],3,3,3,3,3,3,3],5);
 (%o93)	-3/4
-(%i94)	henseltofarey([[0],0,0,0,0,0,0],5);
+(%i94)	hensel_to_farey([[0],0,0,0,0,0,0],5);
 (%o94)	0
 \end{verbatim}
 
 From \cite{6} (pg 12):
 \begin{verbatim}
-(%i95)	henseltofarey([[0],2,3,1,5],7);
+(%i95)	hensel_to_farey([[0],2,3,1,5],7);
 (%o95)	9/43
 \end{verbatim}
 
 From \cite{7} (pp. 100 and ff):
 \begin{verbatim}
-(%i96)	henseltofarey([[0],0,2,4,1],5);
+(%i96)	hensel_to_farey([[0],0,2,4,1],5);
 (%o96)	5/8
-(%i97)	henseltofarey([[1],2,4,1,4],5);
+(%i97)	hensel_to_farey([[1],2,4,1,4],5);
 (%o97)	5/8
-(%i98)	henseltofarey([[-1],3,2,2,2],5);
+(%i98)	hensel_to_farey([[-1],3,2,2,2],5);
 (%o98)	1/10
-(%i99)	henseltofarey([[0],3,2,2,2],5);
+(%i99)	hensel_to_farey([[0],3,2,2,2],5);
 (%o99)	1/2
-(%i100)	henseltofarey([[0],2,3,1,3],5);
+(%i100)	hensel_to_farey([[0],2,3,1,3],5);
 (%o100)	1/3
-(%i101)	henseltofarey([[0],0,6,0,6],7);
+(%i101)	hensel_to_farey([[0],0,6,0,6],7);
 (%o101)	-7/8
 \end{verbatim}
 
@@ -536,25 +536,25 @@ A quick check:
 
 Example from \cite{11}:
 \begin{verbatim}
-(%i104)	henseltofarey([[0],2,2,1,0],5);
+(%i104)	hensel_to_farey([[0],2,2,1,0],5);
 (%o104)	4/17
-(%i105)	henseltofarey([[0],1,2,1,4],5);
+(%i105)	hensel_to_farey([[0],1,2,1,4],5);
 (%o105)	2/7
 \end{verbatim}
 
 Examples from the paper \cite{8}:
 \begin{verbatim}
-(%i106)	henseltofarey([[0],2,2,1,0],5);
+(%i106)	hensel_to_farey([[0],2,2,1,0],5);
 (%o106)	4/17
-(%i107)	henseltofarey([[0],2,2,3,4],5);
+(%i107)	hensel_to_farey([[0],2,2,3,4],5);
 (%o107)	17/16
-(%i108)	henseltofarey([[0],4,2,3,4],5);
+(%i108)	hensel_to_farey([[0],4,2,3,4],5);
 (%o108)	13/17
-(%i109)	henseltofarey([[0],1,1,0,0,1,0],3);
+(%i109)	hensel_to_farey([[0],1,1,0,0,1,0],3);
 (%o109)	-13/17
-(%i110)	henseltofarey([[0],1,2,1,4],5);
+(%i110)	hensel_to_farey([[0],1,2,1,4],5);
 (%o110)	2/7
-(%i111)	henseltofarey([[0],3,4,2,3],5);
+(%i111)	hensel_to_farey([[0],3,4,2,3],5);
 (%o111)	11/7
 \end{verbatim}
 
@@ -597,11 +597,11 @@ But it is modulo $p=7$:
 
 If $a$ is a quadratic residue modulo $p$ with root $x$, then another root is
 given by the $y$ such that $y=-x \mod p$. We compute the $p-$adic roots numerically,
-with the aid of Newton's method, using the command \texttt{padicsqrt}, whose syntax is
-\texttt{padicsqrt(number,p)}. The command admits an optional argument fixing the number
-of iterations to be done, as in \texttt{padicsqrt(number,p,iterations)}.
+with the aid of Newton's method, using the command \texttt{padic\_sqrt}, whose syntax is
+\texttt{padic\_sqrt(number,p)}. The command admits an optional argument fixing the number
+of iterations to be done, as in \texttt{padic\_sqrt(number,p,iterations)}.
 \begin{verbatim}
-(%i114)	padicsqrt(2,7);
+(%i114)	padic_sqrt(2,7);
 (%o114)	[215912063945802350977/152672884556058511392,
          2267891697076964737/1603641597827614272]
 \end{verbatim}
@@ -614,7 +614,7 @@ We can get the corresponding Hensel of the roots codes through
 
 Another example: the square root of $7$ in $\mathbb{Q}_3$ (from \cite{9}):
 \begin{verbatim}
-(%i116)	padicsqrt(7,3,3);
+(%i116)	padic_sqrt(7,3,3);
 (%o116)	[977/368,108497/41008]
 \end{verbatim}
 
@@ -625,20 +625,20 @@ make sense to take more than $6$ digits. Hence we do the following:
 \begin{verbatim}
 (%i117)	map(lambda([u],hensel(u,3,6)),%);
 (%o117)	[[[0],1,1,1,0,2,0],[[0],2,1,1,2,0,2]]
-(%i118)	henseltofarey(%[1],3);
+(%i118)	hensel_to_farey(%[1],3);
 (%o118)	1/25
 \end{verbatim}
 
 The result is not exactly the rational we started with, but it is very close
 in $\mathbb{Q}_3$:
 \begin{verbatim}
-(%i119)	padicdist(977/368,1/25,3);
+(%i119)	padic_distance(977/368,1/25,3);
 (%o119)	1/2187
 \end{verbatim}
 
 More examples:
 \begin{verbatim}
-(%i120)	padicsqrt(6,5)[1];
+(%i120)	padic_sqrt(6,5)[1];
 (%o120)	80746825394092993/32964753427463648
 (%i121)	hensel(%,5,4);
 (%o121)	[[0],1,3,0,4]
@@ -647,7 +647,7 @@ More examples:
 The results can be compared against those given in
 the on-line calculator \url{http://www.numbertheory.org/php/p-adic.html}:
 \begin{verbatim}
-(%i122)	padicsqrt(25,7);
+(%i122)	padic_sqrt(25,7);
 (%o122)	[552213837122886833247075521/110442767424206762611644736,5]
 (%i123)	map(lambda([u],hensel(u,7,8)),%);
 (%o123)	[[[0],2,6,6,6,6,6,6,6],[[0],5,0,0,0,0,0,0,0]]
@@ -655,7 +655,7 @@ the on-line calculator \url{http://www.numbertheory.org/php/p-adic.html}:
 
 Example from \cite{10}:
 \begin{verbatim}
-(%i124)	padicsqrt(-2,3);
+(%i124)	padic_sqrt(-2,3);
 (%o124)	[-28545857/22783264,28545857/22783264]
 (%i125)	hensel(%[1],3,8);
 (%o125)	[[0],1,1,2,0,0,2,0,1]
@@ -664,11 +664,11 @@ Example from \cite{10}:
 Again an example from \cite{9}, to see the influence of the choice of initial condition
 in Newton's iteration (notice how we fix the number of iterations as $3$ here):
 \begin{verbatim}
-(%i126)	padicsqrt(1,3,3);
+(%i126)	padic_sqrt(1,3,3);
 (%o126)	[1,3281/3280]
 (%i127)	map(lambda([u],hensel(u,3,8)),%);
 (%o127)	[[[0],1,0,0,0,0,0,0,0],[[0],2,2,2,2,2,2,2,2]]
-(%i128)	map(lambda([u],henseltofarey(u,3)),%);
+(%i128)	map(lambda([u],hensel_to_farey(u,3)),%);
 (%o128)	[1,-1]
 \end{verbatim}
 
@@ -676,30 +676,30 @@ in Newton's iteration (notice how we fix the number of iterations as $3$ here):
 
 \noindent This is a topic of fundamental importance in applications. The algorithm
 	implemented here is Gaussian reduction, and in order to solve the problem $Ax=b$
-	we have the commands \texttt{padicgauss} and
-	\texttt{padicbacksub}. The first one triangularizes the system, and its syntax
-	is \texttt{padicgauss(B,p)}, where $B=A|b$ is the augmented matrix of the system
+	we have the commands \texttt{padic\_gauss} and
+	\texttt{padic\_backsub}. The first one triangularizes the system, and its syntax
+	is \texttt{padic\_gauss(B,p)}, where $B=A|b$ is the augmented matrix of the system
 	(that is, the coefficient matrix $A$ augmented with the column $b$ of non
 	homogeneous terms). The resulting triangular matrix is processed
-	by \texttt{padicbacksub} to obtain the Hensel codes of the solution.
+	by \texttt{padic\_backsub} to obtain the Hensel codes of the solution.
 
 The following examples are from \cite{4}:
 \begin{verbatim}
 (%i129)	D:matrix([3,1,3,16],[1,3,1,8],[1,1,3,12])$
-(%i130)	padicgauss(D,11);
+(%i130)	padic_gauss(D,11);
 (%o130)	matrix(
 		[[[0],3,0,0,0],	[[0],1,0,0,0],	[[0],3,0,0,0],	[[0],5,1,0,0]],
 		[[[0],0,0,0,0],	[[0],10,3,7,3],	[[0],0,0,0,0],	[[0],10,3,7,3]],
 		[[[0],0,0,0,0],	[[0],0,0,0,0],	[[0],2,0,0,0],	[[0],6,0,0,0]]
 	)
-(%i131)	padicbacksub(%,11);
+(%i131)	padic_backsub(%,11);
 (%o131)	[[[0],2,0,0,0],[[0],1,0,0,0],[[0],3,0,0,0]]
 \end{verbatim}
 
 By converting to Farey fractions, we get the rational form of the solutions:
 
 \begin{verbatim}
-(%i132)	map(lambda([x],henseltofarey(x,11)),%);
+(%i132)	map(lambda([x],hensel_to_farey(x,11)),%);
 (%o132)	[2,1,3]
 \end{verbatim}
 
@@ -711,19 +711,19 @@ Another example:
 		[-3,	0,	2,	-5],
 		[4,	-5,	-1,	0]
 	)
-(%i134)	padicgauss(C,5);
+(%i134)	padic_gauss(C,5);
 (%o134)	matrix(
 		[[[0],2,0,0,0,0,0],	[[0],2,0,0,0,0,0],	[[0],4,4,4,4,4,4],	[[1],1,0,0,0,0,0]],
 		[[[0],0,0,0,0,0,0],	[[0],3,0,0,0,0,0],	[[0],3,2,2,2,2,2],	[[1],3,2,2,2,2,2]],
 		[[[0],0,0,0,0,0,0],	[[0],0,0,0,0,0,0],	[[0],0,3,2,2,2,2],	[[0],0,2,2,2,2,2]]
 	)
-(%i135)	padicbacksub(%,5);
+(%i135)	padic_backsub(%,5);
 (%o135)	[[[-2],0,0,1,0,0,0],[[-2],0,0,1,0,0,0],[[-2],0,0,4,4,4,4]]
 \end{verbatim}
 
 We convert the solution to rational (Farey) expressions:
 \begin{verbatim}
-(%i136)	map(lambda([x],henseltofarey(x,5)),%);
+(%i136)	map(lambda([x],hensel_to_farey(x,5)),%);
 (%o136)	[1,1,-1]
 \end{verbatim}
 
@@ -746,11 +746,11 @@ The examples above were trivial, the only intention was to show
 	[2,2,2,2,2,2,2,2,2,1,3],
 	[1,1,1,1,1,1,1,1,1,1,1]
 	)$
-(%i138)	padicgauss(E,8209)$
+(%i138)	padic_gauss(E,8209)$
 (%i139)	time(%);
 (%o139)	[1.038]
-(%i140)	padicbacksub(%th(2),8209)$
-(%i141)	map(lambda([x],henseltofarey(x,8209)),%);
+(%i140)	padic_backsub(%th(2),8209)$
+(%i141)	map(lambda([x],hensel_to_farey(x,8209)),%);
 (%o141)	[-1,8,-21,8,20,-19,-3,19,-9,-1]
 \end{verbatim}
 
@@ -779,29 +779,29 @@ For example:
 		[1/4,	1/5,	1/6,	1/7,	1/8,	743/840],
 		[1/5,	1/6,	1/7,	1/8,	1/9,	125/168]
 	)
-(%i143)	padicgauss(F,8209)$
+(%i143)	padic_gauss(F,8209)$
 (%i144)	time(%);
 (%o144)	[0.161]
-(%i145)	padicbacksub(%th(2),8209);
+(%i145)	padic_backsub(%th(2),8209);
 (%o145)	[[[0],0,0,0,0,0,0,0,0],[[0],21,0,0,0,0,0,0,0],
          [[0],8120,8208,8208,8208,8208,8208,8208,8208],
          [[0],141,0,0,0,0,0,0,0],[[0],8140,8208,8208,8208,8208,8208,8208,8208]]
-(%i146)	map(lambda([x],henseltofarey(x,8209)),%);
+(%i146)	map(lambda([x],hensel_to_farey(x,8209)),%);
 (%o146)	[0,21,-89,141,-69]
 \end{verbatim}
 
-Observe that \texttt{padicgauss} automatically chooses the number $t$ of
+Observe that \texttt{padic\_gauss} automatically chooses the number $t$ of
 digits in the Hensel codes of the solution. There will be a lot of situatons
 where our simple heuristics for choosing $t$ will lead to bad values. 
 For those cases, one can manually choose $t$ as another argument,
-using the alternative function \texttt{padicgauss2}. 
+using the alternative function \texttt{padic\_gauss2}. 
 Below we choose $8$ digits to solve the system defined by the matrix $E$
 defined above, getting the same result as before:
 
 \begin{verbatim}
-(%i147)	padicgauss2(E,8209,8)$
-(%i148)	padicbacksub(%,8209)$
-(%i149)	map(lambda([x],henseltofarey(x,8209)),%);
+(%i147)	padic_gauss2(E,8209,8)$
+(%i148)	padic_backsub(%,8209)$
+(%i149)	map(lambda([x],hensel_to_farey(x,8209)),%);
 (%o149)	[-1,8,-21,8,20,-19,-3,19,-9,-1]
 \end{verbatim}
 
@@ -828,13 +828,13 @@ Let us see how p-adic arithmetics deal with the high condition number of
 Notice that the non-homogeneous coefficients in $M_2$ are really close to the initial ones in 
 $M_1$:
 \begin{verbatim}
-(%i152)	makelist(padicdist(M1[j][6],M2[j][6],29),j,1,length(M1));
+(%i152)	makelist(padic_distance(M1[j][6],M2[j][6],29),j,1,length(M1));
 (%o152)	[1/20511149,1/24389,1/20511149,1/500246412961,1/17249876309]
 \end{verbatim}
 
 In this case, the output has a size small enough to be displayed:
 \begin{verbatim}
-(%i153)	padicgauss2(M1,29,6);
+(%i153)	padic_gauss2(M1,29,6);
 \end{verbatim}
 \begin{sideways}
 \begin{minipage}{\textheight}
@@ -852,18 +852,18 @@ In this case, the output has a size small enough to be displayed:
 \end{sideways}
 
 \begin{verbatim}
-(%i157)	padicbacksub(%,29);
+(%i157)	padic_backsub(%,29);
 (%o157)	[[[0],9,4,0,19,18,1],[[0],20,16,25,14,20,3],
          [[0],19,6,17,8,15,19],[[0],10,20,28,24,27,18],
          [[0],6,21,15,15,0,11]]
-(%i158)	map(lambda([x],henseltofarey(x,29)),%);
+(%i158)	map(lambda([x],hensel_to_farey(x,29)),%);
 (%o158)	[1/73774969,2/122364169,-4725/9013,1/83362185,2/80199829]
 \end{verbatim}
 
 The solutions of the original system and the perturbed one, are quite close
 (in the $p-$adic distance, of course):
 \begin{verbatim}
-(%i159)	makelist(padicdist(%[j],%th(4)[j],29),j,1,length(%));
+(%i159)	makelist(padic_distance(%[j],%th(4)[j],29),j,1,length(%));
 (%o159)	[1/24389,1/24389,1/24389,1/24389,1/24389]
 \end{verbatim}
 

--- a/padics-doc.tex
+++ b/padics-doc.tex
@@ -315,9 +315,9 @@ Let us compare this with the table presented in \cite{2}:
 \noindent The basic arithmetic functions are implemented as:
 \begin{itemize}
 	\item  \texttt{padic\_sum} (for sum, addition)
-	\item  \texttt{padic\_subtract} (for difference, substraction)
+	\item  \texttt{padic\_subtract} (for difference, subtraction)
 	\item  \texttt{padic\_multiply} (for product, multiplication)
-	\item  \texttt{padivdiv} (for division, quotient)
+	\item  \texttt{padic\_divide} (for division, quotient)
 \end{itemize}
 
 The syntax is quite evident: each function takes the arguments

--- a/padics.mac
+++ b/padics.mac
@@ -24,10 +24,20 @@ Topics covered are:
 6. p-adic systems of linear equations
 
 REMARK: Some functions in the package make use of the commands
-firstn and lastn, which require a Maxima version 5.41 or higher
+firstn and lastn, which were introduced in Maxima 5.39.
+If firstn or lastn are not detected as built-in functions,
+equivalent functions are defined here.
 */
 
 ratprint:false$
+
+if ?fboundp (firstn) = false
+  then (print ("padics: no built-in function 'firstn'; I'll define my own."),
+        firstn (l, n) := block ([m: length(l)], if n >= m then l else rest (l, n - m)));
+
+if ?fboundp (lastn) = false
+  then (print ("padics: no built-in function 'lastn'; I'll define my own."),
+        lastn (l, n) := block ([m: length(l)], if n >= m then l else rest (l, m - n)));
 
 /*
 Let us first define the p-adic order of an integer

--- a/padics.mac
+++ b/padics.mac
@@ -197,7 +197,7 @@ tmp[1]:tmp[1]+1,
 cons(first(h),tmp)
 )$
 
-padicsubstract(l1,l2,p):=padic_sum(l1,henselcomp(l2,p),p)$
+padic_subtract(l1,l2,p):=padic_sum(l1,henselcomp(l2,p),p)$
 
 redu(p,u,ll):=block([tmp1,tmp2,rmdr,carry,tot,token],
 	tmp1:map(lambda([z],divide(z,p)),u*ll),
@@ -254,7 +254,7 @@ tmp[1]:tmp[1]+1,
 tmp
 )$
 
-padicsubstractb(l1,l2,p):=block([rmdrs,carry,tot,token],
+padic_subtractb(l1,l2,p):=block([rmdrs,carry,tot,token],
 rmdrs:map(lambda([x],divide(x,p)),l1+henselcompb(l2,p)),
 carry:cons(0,rest(map(first,rmdrs),-1)),
 tot:map(second,rmdrs)+carry,
@@ -291,14 +291,14 @@ counter:1,
 tmp:[],
 par:mod(invd0*rest(l1)[counter],p),
 tmp:endcons(par,tmp),
-rmd:padicsubstractb(rest(l1),rest(multb(par,rest(l2),p),1-counter),p),
+rmd:padic_subtractb(rest(l1),rest(multb(par,rest(l2),p),1-counter),p),
 token:apply("+",rmd),
 if is(equal(token,0)) then return(cons([quot],  append(tmp,makelist(0,k,1,length(l2)-2))  )) else do
 (counter:counter +1,
 while (is(not(equal(token,0)))) do
     (
     par:mod(invd0*rmd[counter],p),
-    rmd:padicsubstractb(rmd,flatten(cons(makelist(0,k,1,counter-1),rest(multb(par,rest(l2),p),1-counter))),p),
+    rmd:padic_subtractb(rmd,flatten(cons(makelist(0,k,1,counter-1),rest(multb(par,rest(l2),p),1-counter))),p),
     token:apply("+",rmd),
     tmp:endcons(par,tmp),
     counter:counter+1
@@ -469,7 +469,7 @@ padicbacksub(M,p):=block([n:length(M),t:length(rest(flatten(M[1,1]))),x,ratprint
 x:makelist(cons([0],makelist(0,k,1,t)),j,1,n),
 x[n]:padicdiv(M[n][n+1],M[n][n],p),
 for i:n-1 thru 1 step -1 do
-    x[i]:padicdiv(padicsubstract(M[i][n+1],padicdotp(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
+    x[i]:padicdiv(padic_subtract(M[i][n+1],padicdotp(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
 x
 )$
 
@@ -516,7 +516,7 @@ while is((h<m) and (k<n)) do (
     for i:h+1 thru m do (
             f:padicdiv(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
-            for j:k+1 thru n do A[i,j]:padicsubstract(A[i,j],padicmult(f,A[h,j],p),p)
+            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padicmult(f,A[h,j],p),p)
             ),
     h:h+1,
     k:k+1,
@@ -545,7 +545,7 @@ while is((h<m) and (k<n)) do (
     for i:h+1 thru m do (
             f:padicdiv(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
-            for j:k+1 thru n do A[i,j]:padicsubstract(A[i,j],padicmult(f,A[h,j],p),p)
+            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padicmult(f,A[h,j],p),p)
             ),
     h:h+1,
     k:k+1,

--- a/padics.mac
+++ b/padics.mac
@@ -315,7 +315,7 @@ so that the first digit after the dot is not
 zero:
 */
 
-normalhensel(lista):=block([s,ss],
+normalize_hensel(lista):=block([s,ss],
 if is(equal(unique(rest(lista)),[0])) then lista
 else
 (s:first(lista[1]),
@@ -324,14 +324,14 @@ cons([ss+s-1],rest(lista,ss)))
 )$
 
 padic_divide(l1,l2,p):=block([lon1,lon2,lon,s1,s2,tmp],
-lon1:length(normalhensel(l2)),
+lon1:length(normalize_hensel(l2)),
 lon2:length(l2),
 if is(lon1 < lon2)
 then 
 (
 lon:lon2 - lon1,
 s1:rest(l1,-lon),
-s2:normalhensel(l2),
+s2:normalize_hensel(l2),
 tmp:padic_dividei(s1,s2,p),
 cons([first(tmp[1])-lon],flatten(cons(makelist(0,k,1,lon),rest(tmp))))   
     )
@@ -370,7 +370,7 @@ zerodetect(ll):=is(equal(sublist_indices(rest(ll),lambda([x],is(not(equal(x,0)))
 pdetect(ll,p):=is(equal(unique(rest(ll,2)),[p-1]))$
 
 henseltofareyaux(lista,p):=block(
-    [normli:normalhensel(lista),lnormli,ll:rest(lista),r:length(lista)-1,m,N,k,a,b,q,c,soln:0],
+    [normli:normalize_hensel(lista),lnormli,ll:rest(lista),r:length(lista)-1,m,N,k,a,b,q,c,soln:0],
     local(a,b,q,c),
 lnormli:length(normli),
 if is(equal(unique(rest(lista)),[0])) then return(0) elseif
@@ -385,7 +385,7 @@ for i:1 step 1 while is(not(equal(a[i-1],0))) do (
     q[i]:first(divide(a[i-2],a[i-1])),
     a[i]:second(divide(a[i-2],a[i-1])),
     b[i]:b[i-2]-q[i]*b[i-1],
-    c[i]:firstn(normalhensel(hensel(a[i]/b[i],p,r)),lnormli),
+    c[i]:firstn(normalize_hensel(hensel(a[i]/b[i],p,r)),lnormli),
     block(if (c[i]=normli and ((abs(a[i])>0 and abs(a[i])<=N) and (abs(b[i])>0 and abs(b[i])<=N))) then return(soln:a[i]/b[i])) 
             /*It seems that return only exits from here but not from the parent function, hence the line below*/
     ),

--- a/padics.mac
+++ b/padics.mac
@@ -234,7 +234,7 @@ tot
 )$
 
 
-padicmult(l1,l2,p):=block([l1b,l2b,pp,bigl,lon,tmp],local(tmp),
+padic_multiply(l1,l2,p):=block([l1b,l2b,pp,bigl,lon,tmp],local(tmp),
 l1b:rest(l1),
 l2b:rest(l2),
 pp:first(l1[1])+first(l2[1]),
@@ -269,7 +269,7 @@ while (is(not(equal(token,0)))) do
 tot
 )$
 
-multb(u,ll,p):=block([rmdrs,carry,tot,token],
+padic_multiplyb(u,ll,p):=block([rmdrs,carry,tot,token],
 rmdrs:map(lambda([x],divide(x,p)),u*ll),
 carry:cons(0,rest(map(first,rmdrs),-1)),
 tot:map(second,rmdrs)+carry,
@@ -291,14 +291,14 @@ counter:1,
 tmp:[],
 par:mod(invd0*rest(l1)[counter],p),
 tmp:endcons(par,tmp),
-rmd:padic_subtractb(rest(l1),rest(multb(par,rest(l2),p),1-counter),p),
+rmd:padic_subtractb(rest(l1),rest(padic_multiplyb(par,rest(l2),p),1-counter),p),
 token:apply("+",rmd),
 if is(equal(token,0)) then return(cons([quot],  append(tmp,makelist(0,k,1,length(l2)-2))  )) else do
 (counter:counter +1,
 while (is(not(equal(token,0)))) do
     (
     par:mod(invd0*rmd[counter],p),
-    rmd:padic_subtractb(rmd,flatten(cons(makelist(0,k,1,counter-1),rest(multb(par,rest(l2),p),1-counter))),p),
+    rmd:padic_subtractb(rmd,flatten(cons(makelist(0,k,1,counter-1),rest(padic_multiplyb(par,rest(l2),p),1-counter))),p),
     token:apply("+",rmd),
     tmp:endcons(par,tmp),
     counter:counter+1
@@ -457,7 +457,7 @@ A substitute of `innerproduct' for p-adics
 */
 
 padicdotp(l1,l2,p):=block([pp],local(pp),
-pp:makelist(padicmult(l1[i],l2[i],p),i,1,length(l1)),
+pp:makelist(padic_multiply(l1[i],l2[i],p),i,1,length(l1)),
 xreduce(lambda([[x]],padic_sum(x[1],x[2],p)),pp)
 )$
 
@@ -516,7 +516,7 @@ while is((h<m) and (k<n)) do (
     for i:h+1 thru m do (
             f:padicdiv(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
-            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padicmult(f,A[h,j],p),p)
+            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padic_multiply(f,A[h,j],p),p)
             ),
     h:h+1,
     k:k+1,
@@ -545,7 +545,7 @@ while is((h<m) and (k<n)) do (
     for i:h+1 thru m do (
             f:padicdiv(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
-            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padicmult(f,A[h,j],p),p)
+            for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padic_multiply(f,A[h,j],p),p)
             ),
     h:h+1,
     k:k+1,

--- a/padics.mac
+++ b/padics.mac
@@ -503,7 +503,7 @@ included a small heuristics to fix a maximum of t=8,
 that should suffice for simple computations
 */
 
-padicgauss(BBB,p):=block([s,t,lam:(sqrt(5)-1)/2,m:length(BBB),n:length(transpose(BBB)),B2H,A,h,k,c,tmp,r,f],local(B2H,A),
+padic_gauss(BBB,p):=block([s,t,lam:(sqrt(5)-1)/2,m:length(BBB),n:length(transpose(BBB)),B2H,A,h,k,c,tmp,r,f],local(B2H,A),
 t:digitsnumber(BBB,p),
 B2H[i,j]:=hensel(BBB[i][j],p,t),
 A:genmatrix(B2H,m,n),
@@ -533,7 +533,7 @@ For those cases, one can manually choose t with the
 alternative command padicgauss2
 */
 
-padicgauss2(BBB,p,t):=block([m:length(BBB),n:length(transpose(BBB)),B2H,A,h,k,c,tmp,r,f],local(B2H,A),
+padic_gauss2(BBB,p,t):=block([m:length(BBB),n:length(transpose(BBB)),B2H,A,h,k,c,tmp,r,f],local(B2H,A),
 B2H[i,j]:=hensel(BBB[i][j],p,t),
 A:genmatrix(B2H,m,n),
 h:1,k:1,c:0,

--- a/padics.mac
+++ b/padics.mac
@@ -164,7 +164,7 @@ differences, products and divisions. Lots of
 auxiliary functions there
 */
 
-padicsum(l1,l2,p):=block([pp,gg,mm,n1,n2,rmdrs,carry,tot,token],
+padic_sum(l1,l2,p):=block([pp,gg,mm,n1,n2,rmdrs,carry,tot,token],
 pp:apply(min,append(l1[1],l2[1])),
 if (l1[1][1]>=l2[1][1]) then (gg:l1,mm:l2) else (gg:l2,mm:l1),
 if is(not(equal(gg[1][1],mm[1][1]))) then
@@ -197,7 +197,7 @@ tmp[1]:tmp[1]+1,
 cons(first(h),tmp)
 )$
 
-padicsubstract(l1,l2,p):=padicsum(l1,henselcomp(l2,p),p)$
+padicsubstract(l1,l2,p):=padic_sum(l1,henselcomp(l2,p),p)$
 
 redu(p,u,ll):=block([tmp1,tmp2,rmdr,carry,tot,token],
 	tmp1:map(lambda([z],divide(z,p)),u*ll),
@@ -218,7 +218,7 @@ redu(p,u,ll):=block([tmp1,tmp2,rmdr,carry,tot,token],
 	    tot
 )$
 
-padicsumb(l1,l2,p):=block([rmdrs,carry,tot,token],
+padic_sumb(l1,l2,p):=block([rmdrs,carry,tot,token],
 rmdrs:map(lambda([x],divide(x,p)),l1+l2),
 carry:cons(0,rest(map(first,rmdrs),-1)),
 tot:map(second,rmdrs)+carry,
@@ -243,7 +243,7 @@ lon:length(bigl),
 tmp[1]:bigl[1],
 for k:2 thru lon do
 (
-tmp[k]:padicsumb(tmp[k-1],bigl[k],p)
+tmp[k]:padic_sumb(tmp[k-1],bigl[k],p)
 ),
 cons([pp],tmp[lon])
 )$
@@ -458,7 +458,7 @@ A substitute of `innerproduct' for p-adics
 
 padicdotp(l1,l2,p):=block([pp],local(pp),
 pp:makelist(padicmult(l1[i],l2[i],p),i,1,length(l1)),
-xreduce(lambda([[x]],padicsum(x[1],x[2],p)),pp)
+xreduce(lambda([[x]],padic_sum(x[1],x[2],p)),pp)
 )$
 
 /*

--- a/padics.mac
+++ b/padics.mac
@@ -191,13 +191,13 @@ while (is(not(equal(token,0)))) do
 cons([pp],tot)
 )$
 
-henselcomp(h,p):=block([tmp],
+hensel_complement(h,p):=block([tmp],
 tmp:(p-1)-rest(h),
 tmp[1]:tmp[1]+1,
 cons(first(h),tmp)
 )$
 
-padic_subtract(l1,l2,p):=padic_sum(l1,henselcomp(l2,p),p)$
+padic_subtract(l1,l2,p):=padic_sum(l1,hensel_complement(l2,p),p)$
 
 redu(p,u,ll):=block([tmp1,tmp2,rmdr,carry,tot,token],
 	tmp1:map(lambda([z],divide(z,p)),u*ll),
@@ -248,14 +248,14 @@ tmp[k]:padic_sumb(tmp[k-1],bigl[k],p)
 cons([pp],tmp[lon])
 )$
 
-henselcompb(h,p):=block([tmp],
+hensel_complementb(h,p):=block([tmp],
 tmp:(p-1)-h,
 tmp[1]:tmp[1]+1,
 tmp
 )$
 
 padic_subtractb(l1,l2,p):=block([rmdrs,carry,tot,token],
-rmdrs:map(lambda([x],divide(x,p)),l1+henselcompb(l2,p)),
+rmdrs:map(lambda([x],divide(x,p)),l1+hensel_complementb(l2,p)),
 carry:cons(0,rest(map(first,rmdrs),-1)),
 tot:map(second,rmdrs)+carry,
 token:apply("+",carry),

--- a/padics.mac
+++ b/padics.mac
@@ -284,7 +284,7 @@ while (is(not(equal(token,0)))) do
 tot
 )$
 
-padicdivi(l1,l2,p):=block([invd0,quot,tmp,rmd,token,par,counter],local(tmp,rmd),
+padic_dividei(l1,l2,p):=block([invd0,quot,tmp,rmd,token,par,counter],local(tmp,rmd),
 invd0:inv_mod(second(l2),p),
 quot:first(l1[1])-first(l2[1]),
 counter:1,
@@ -323,7 +323,7 @@ ss:first(sublist_indices(rest(lista),lambda([z],is(not(equal(z,0)))))),
 cons([ss+s-1],rest(lista,ss)))
 )$
 
-padicdiv(l1,l2,p):=block([lon1,lon2,lon,s1,s2,tmp],
+padic_divide(l1,l2,p):=block([lon1,lon2,lon,s1,s2,tmp],
 lon1:length(normalhensel(l2)),
 lon2:length(l2),
 if is(lon1 < lon2)
@@ -332,11 +332,11 @@ then
 lon:lon2 - lon1,
 s1:rest(l1,-lon),
 s2:normalhensel(l2),
-tmp:padicdivi(s1,s2,p),
+tmp:padic_dividei(s1,s2,p),
 cons([first(tmp[1])-lon],flatten(cons(makelist(0,k,1,lon),rest(tmp))))   
     )
 else
-padicdivi(l1,l2,p)  
+padic_dividei(l1,l2,p)  
 )$
 
 /*
@@ -467,9 +467,9 @@ The function for backsubstitution
 
 padicbacksub(M,p):=block([n:length(M),t:length(rest(flatten(M[1,1]))),x,ratprint:false],local(x),
 x:makelist(cons([0],makelist(0,k,1,t)),j,1,n),
-x[n]:padicdiv(M[n][n+1],M[n][n],p),
+x[n]:padic_divide(M[n][n+1],M[n][n],p),
 for i:n-1 thru 1 step -1 do
-    x[i]:padicdiv(padic_subtract(M[i][n+1],padicdotp(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
+    x[i]:padic_divide(padic_subtract(M[i][n+1],padicdotp(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
 x
 )$
 
@@ -514,7 +514,7 @@ while is((h<m) and (k<n)) do (
     if is(equal(A[r,k],cons([0],makelist(0,j,1,t)))) then k:k+1 else (
     A:rowswap(A,h,r+c),
     for i:h+1 thru m do (
-            f:padicdiv(A[i,k],A[h,k],p),
+            f:padic_divide(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
             for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padic_multiply(f,A[h,j],p),p)
             ),
@@ -543,7 +543,7 @@ while is((h<m) and (k<n)) do (
     if is(equal(A[r,k],cons([0],makelist(0,j,1,t)))) then k:k+1 else (
     A:rowswap(A,h,r+c),
     for i:h+1 thru m do (
-            f:padicdiv(A[i,k],A[h,k],p),
+            f:padic_divide(A[i,k],A[h,k],p),
             A[i,k]:cons([0],makelist(0,j,1,t)),
             for j:k+1 thru n do A[i,j]:padic_subtract(A[i,j],padic_multiply(f,A[h,j],p),p)
             ),

--- a/padics.mac
+++ b/padics.mac
@@ -82,7 +82,7 @@ Reduction to the canonical form of a rational number
 The result has the form of a list [p^porder(r),a'/b']
 */
 
-padiccan(r,p):=block([numerat,denomin,pp,qq,dd],
+padic_canonical(r,p):=block([numerat,denomin,pp,qq,dd],
 if is(equal(r,0)) then [1,0] else
 (
 numerat:fix(ratnum(r)),
@@ -122,7 +122,7 @@ The output has the form [[exponent],mantissa]
 */
 
 hensel(r,p,N):=block([tmp,ee,c,d,a,aux],local(c,d,a,aux),
-tmp:padiccan(r,p),
+tmp:padic_canonical(r,p),
 ee:fix(radcan(log(tmp[1])/log(p))),
 c[1]:fix(ratnum(tmp[2])),
 d[1]:fix(ratdenom(tmp[2])),
@@ -142,7 +142,7 @@ found in textbooks and expository works
 */
 
 nicehensel(r,p,N):=block([tmp,ee,c,d,a,aux,AA],local(c,d,a,aux,AA),
-tmp:padiccan(r,p),
+tmp:padic_canonical(r,p),
 ee:fix(log(tmp[1])/log(p)),
 c[1]:fix(ratnum(tmp[2])),
 d[1]:fix(ratdenom(tmp[2])),

--- a/padics.mac
+++ b/padics.mac
@@ -365,17 +365,17 @@ Functions for converting Hensel codes to
 Farey fractions
 */
 
-zerodetect(ll):=is(equal(sublist_indices(rest(ll),lambda([x],is(not(equal(x,0))))),[1]))$
+hensel_zerodetect(ll):=is(equal(sublist_indices(rest(ll),lambda([x],is(not(equal(x,0))))),[1]))$
 
-pdetect(ll,p):=is(equal(unique(rest(ll,2)),[p-1]))$
+hensel_pdetect(ll,p):=is(equal(unique(rest(ll,2)),[p-1]))$
 
 henseltofareyaux(lista,p):=block(
     [normli:normalize_hensel(lista),lnormli,ll:rest(lista),r:length(lista)-1,m,N,k,a,b,q,c,soln:0],
     local(a,b,q,c),
 lnormli:length(normli),
 if is(equal(unique(rest(lista)),[0])) then return(0) elseif
-zerodetect(lista) then return(second(lista)*p^(first(first(lista)))) elseif
-pdetect(lista,p) then return(second(lista)-p) elseif
+hensel_zerodetect(lista) then return(second(lista)*p^(first(first(lista)))) elseif
+hensel_pdetect(lista,p) then return(second(lista)-p) elseif
     is(equal(unique(lastn(rest(lista),ceiling(r/2))),[0])) then return(sum(rest(lista)[k]*p^(k-1),k,1,floor(r/2))) else (
 m:p^r,
 N:ceiling(sqrt((m-1)/2)),

--- a/padics.mac
+++ b/padics.mac
@@ -434,7 +434,7 @@ y=-x mod p. We compute the padic roots with Newton's
 method 
 */
 
-padicsqrt(n,p,[k]):=block([tmp,iter],local(iter1,iter2),
+padic_sqrt(n,p,[k]):=block([tmp,iter],local(iter1,iter2),
 tmp:sqrtmod(n,p),
 if is(stringp(tmp)) then return("There does not exist a square root")
 elseif is(equal(length(k),0)) then

--- a/padics.mac
+++ b/padics.mac
@@ -530,7 +530,7 @@ A
 There will be a lot of situatons where our simple
 heuristis for choosing t will lead to bad values.
 For those cases, one can manually choose t with the
-alternative command padicgauss2
+alternative command padic_gauss2
 */
 
 padic_gauss2(BBB,p,t):=block([m:length(BBB),n:length(transpose(BBB)),B2H,A,h,k,c,tmp,r,f],local(B2H,A),

--- a/padics.mac
+++ b/padics.mac
@@ -113,7 +113,7 @@ p^(qq-pp)
 The associated p-adic distance:
 */
 
-padicdist(x,y,p):=padic_norm(x-y,p)$
+padic_distance(x,y,p):=padic_norm(x-y,p)$
 
 /*
 Construction of Hensel (pseudo)codes, which basically are

--- a/padics.mac
+++ b/padics.mac
@@ -43,7 +43,7 @@ if ?fboundp (lastn) = false
 Let us first define the p-adic order of an integer
 */
 
-padicord(n,p):=block([listaf,subind,lsubind],
+padic_order_integer(n,p):=block([listaf,subind,lsubind],
 if is(equal(n,0)) then inf elseif (n>0) then
 (   
 listaf:ifactors(fix(ratnum(n))),
@@ -61,17 +61,17 @@ return(if is(equal(lsubind,0)) then 0 else second(listaf[first(subind)]))
 )$
 
 /*
-The function padicord will be used only as an auxiliary one. The actual p-adic order function,
+The function padic_order_integer will be used only as an auxiliary one. The actual p-adic order function,
 valid acting on any rational r, is this
 */
 
-padicorder(r,p):=block([numerat,denomin,pp,qq,dd],
+padic_order(r,p):=block([numerat,denomin,pp,qq,dd],
 if is(equal(r,0)) then inf else
 (
 numerat:fix(ratnum(r)),
 denomin:fix(ratdenom(r)),
-pp:padicord(numerat,p),
-qq:padicord(denomin,p),
+pp:padic_order_integer(numerat,p),
+qq:padic_order_integer(denomin,p),
 pp-qq
 )
 )$
@@ -87,8 +87,8 @@ if is(equal(r,0)) then [1,0] else
 (
 numerat:fix(ratnum(r)),
 denomin:fix(ratdenom(r)),
-pp:padicord(numerat,p),
-qq:padicord(denomin,p),
+pp:padic_order_integer(numerat,p),
+qq:padic_order_integer(denomin,p),
 dd:pp-qq,
 [p^(dd),(numerat/p^pp)/(denomin/p^qq)]
 )
@@ -103,8 +103,8 @@ if is(equal(r,0)) then 0 else
 (
 numerat:fix(ratnum(r)),
 denomin:fix(ratdenom(r)),
-pp:padicord(numerat,p),
-qq:padicord(denomin,p),
+pp:padic_order_integer(numerat,p),
+qq:padic_order_integer(denomin,p),
 p^(qq-pp)
 )
 )$

--- a/padics.mac
+++ b/padics.mac
@@ -369,7 +369,7 @@ hensel_zerodetect(ll):=is(equal(sublist_indices(rest(ll),lambda([x],is(not(equal
 
 hensel_pdetect(ll,p):=is(equal(unique(rest(ll,2)),[p-1]))$
 
-henseltofareyaux(lista,p):=block(
+hensel_to_fareyaux(lista,p):=block(
     [normli:normalize_hensel(lista),lnormli,ll:rest(lista),r:length(lista)-1,m,N,k,a,b,q,c,soln:0],
     local(a,b,q,c),
 lnormli:length(normli),
@@ -405,11 +405,11 @@ miserably. We take this fact into account in the final
 version below:
 */
 
-henseltofarey(lista,p):=block([m:first(flatten(lista))],
+hensel_to_farey(lista,p):=block([m:first(flatten(lista))],
 if is(equal(m,0)) then  
-    henseltofareyaux(lista,p)
+    hensel_to_fareyaux(lista,p)
 else
-    p^m*henseltofareyaux(append([[0]],rest(lista)),p) 
+    p^m*hensel_to_fareyaux(append([[0]],rest(lista)),p) 
 )$
 
 /*

--- a/padics.mac
+++ b/padics.mac
@@ -465,7 +465,7 @@ xreduce(lambda([[x]],padic_sum(x[1],x[2],p)),pp)
 The function for backsubstitution
 */
 
-padicbacksub(M,p):=block([n:length(M),t:length(rest(flatten(M[1,1]))),x,ratprint:false],local(x),
+padic_backsub(M,p):=block([n:length(M),t:length(rest(flatten(M[1,1]))),x,ratprint:false],local(x),
 x:makelist(cons([0],makelist(0,k,1,t)),j,1,n),
 x[n]:padic_divide(M[n][n+1],M[n][n],p),
 for i:n-1 thru 1 step -1 do

--- a/padics.mac
+++ b/padics.mac
@@ -456,7 +456,7 @@ by the Gauss method
 A substitute of `innerproduct' for p-adics
 */
 
-padicdotp(l1,l2,p):=block([pp],local(pp),
+padic_inner_product(l1,l2,p):=block([pp],local(pp),
 pp:makelist(padic_multiply(l1[i],l2[i],p),i,1,length(l1)),
 xreduce(lambda([[x]],padic_sum(x[1],x[2],p)),pp)
 )$
@@ -469,7 +469,7 @@ padicbacksub(M,p):=block([n:length(M),t:length(rest(flatten(M[1,1]))),x,ratprint
 x:makelist(cons([0],makelist(0,k,1,t)),j,1,n),
 x[n]:padic_divide(M[n][n+1],M[n][n],p),
 for i:n-1 thru 1 step -1 do
-    x[i]:padic_divide(padic_subtract(M[i][n+1],padicdotp(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
+    x[i]:padic_divide(padic_subtract(M[i][n+1],padic_inner_product(rest(list_matrix_entries(row(M,i)),-1),x,p),p),M[i][i],p),
 x
 )$
 

--- a/padics.mac
+++ b/padics.mac
@@ -98,7 +98,7 @@ dd:pp-qq,
 Computation of the p-adic norm of a rational number
 */
 
-padicnorm(r,p):=block([numerat,denomin,pp,qq],
+padic_norm(r,p):=block([numerat,denomin,pp,qq],
 if is(equal(r,0)) then 0 else 
 (
 numerat:fix(ratnum(r)),
@@ -113,7 +113,7 @@ p^(qq-pp)
 The associated p-adic distance:
 */
 
-padicdist(x,y,p):=padicnorm(x-y,p)$
+padicdist(x,y,p):=padic_norm(x-y,p)$
 
 /*
 Construction of Hensel (pseudo)codes, which basically are
@@ -473,7 +473,7 @@ for i:n-1 thru 1 step -1 do
 x
 )$
 
-padicnormh(lista,p):=p^(-first(flatten(lista)))$
+padic_normh(lista,p):=p^(-first(flatten(lista)))$
 
 nonzeroprod(ll):=apply("*",makelist(abs(ll[k]),k,sublist_indices(ll,lambda([x],is(not(equal(x,0)))))))$
 
@@ -509,8 +509,8 @@ B2H[i,j]:=hensel(BBB[i][j],p,t),
 A:genmatrix(B2H,m,n),
 h:1,k:1,c:0,
 while is((h<m) and (k<n)) do (
-    tmp:lmax(makelist(padicnormh(A[j,k],p),j,h,m)),
-    r:first(sublist_indices(makelist(A[j,k],j,h,m),lambda([x],padicnormh(x,p)='tmp))),
+    tmp:lmax(makelist(padic_normh(A[j,k],p),j,h,m)),
+    r:first(sublist_indices(makelist(A[j,k],j,h,m),lambda([x],padic_normh(x,p)='tmp))),
     if is(equal(A[r,k],cons([0],makelist(0,j,1,t)))) then k:k+1 else (
     A:rowswap(A,h,r+c),
     for i:h+1 thru m do (
@@ -538,8 +538,8 @@ B2H[i,j]:=hensel(BBB[i][j],p,t),
 A:genmatrix(B2H,m,n),
 h:1,k:1,c:0,
 while is((h<m) and (k<n)) do (
-    tmp:lmax(makelist(padicnormh(A[j,k],p),j,h,m)),
-    r:first(sublist_indices(makelist(A[j,k],j,h,m),lambda([x],padicnormh(x,p)='tmp))),
+    tmp:lmax(makelist(padic_normh(A[j,k],p),j,h,m)),
+    r:first(sublist_indices(makelist(A[j,k],j,h,m),lambda([x],padic_normh(x,p)='tmp))),
     if is(equal(A[r,k],cons([0],makelist(0,j,1,t)))) then k:k+1 else (
     A:rowswap(A,h,r+c),
     for i:h+1 thru m do (

--- a/rtest_padics.mac
+++ b/rtest_padics.mac
@@ -6,85 +6,85 @@
 (load("padics.mac"), 0);
 0$
 
-padicorder(144,3);
+padic_order(144,3);
 2$
 
-padicorder(17,3);
+padic_order(17,3);
 0$
 
-makelist(padicorder(0,i),i,[2,3,5,7,11,13]);
+makelist(padic_order(0,i),i,[2,3,5,7,11,13]);
 [inf,inf,inf,inf,inf,inf]$
 
-padicorder(3/10,5);
+padic_order(3/10,5);
 -1$
 
-padicorder(36015/88,7);
+padic_order(36015/88,7);
 4$
 
-padicorder(-3/10,5);
+padic_order(-3/10,5);
 -1$
 
-padiccan(0.234,2);
+padic_canonical(0.234,2);
 [1/4,117/125]$
 
-padiccan(0,3);
+padic_canonical(0,3);
 [1,0]$
 
-makelist(padicnorm(0,j),j,[2,3,5,7,11,13,17]);
+makelist(padic_norm(0,j),j,[2,3,5,7,11,13,17]);
 [0,0,0,0,0,0,0]$
 
-padicnorm(17,17);
+padic_norm(17,17);
 1/17$
 
-padicnorm(144,3);
+padic_norm(144,3);
 1/9$
 
-padicnorm(12,5);
+padic_norm(12,5);
 1$
 
-makelist(padicnorm(162/13,k),k,[3,13]);
+makelist(padic_norm(162/13,k),k,[3,13]);
 [1/81,13]$
 
-makelist(padicnorm(140/297,k),k,[2,3,5,7,11]);
+makelist(padic_norm(140/297,k),k,[2,3,5,7,11]);
 [1/4,27,1/5,1/7,11]$
 
-makelist(padicnorm(63/550,k),k,[2,3,5,7,11,13]);
+makelist(padic_norm(63/550,k),k,[2,3,5,7,11,13]);
 [2,1/9,25,1/7,11,1]$
 
-padicnorm(0.234,2);
+padic_norm(0.234,2);
 4$
 
-padicnorm(3/10,5);
+padic_norm(3/10,5);
 5$
 
-padicnorm(40,5);
+padic_norm(40,5);
 1/5$
 
-padicnorm(3/10-40,5);
+padic_norm(3/10-40,5);
 5$
 
-padicnorm(10/12,2);
+padic_norm(10/12,2);
 2$
 
-padicnorm(10/12,5);
+padic_norm(10/12,5);
 1/5$
 
-padicnorm(10/12,7);
+padic_norm(10/12,7);
 1$
 
-padicdist(2,28814,7);
+padic_distance(2,28814,7);
 1/2401$
 
-padicdist(2,3,7);
+padic_distance(2,3,7);
 1$
 
-padicdist(2166^2,2,7);
+padic_distance(2166^2,2,7);
 1/2401$
 
-padicdist(3,3+29^4,29);
+padic_distance(3,3+29^4,29);
 1/707281$
 
-padicdist(82,1,3);
+padic_distance(82,1,3);
 1/81$
 
 /* p-adic expansions (Hensel codes) */
@@ -175,10 +175,10 @@ l1:hensel(3/10,5,4);
 l2:hensel(1/2,5,4);
 [[0],3,2,2,2]$
 
-padicsum(l1,l2,5);
+padic_sum(l1,l2,5);
 [[-1],4,0,0,0]$
 
-padicsum([[2],2,5,1,5],[[-3],3,3,3,2],7);
+padic_sum([[2],2,5,1,5],[[-3],3,3,3,2],7);
 [[-3],3,3,3,2]$
 
 h1:hensel(2/3,5,9);
@@ -187,13 +187,13 @@ h1:hensel(2/3,5,9);
 h2:hensel(5/6,5,9);
 [[1],1,4,0,4,0,4,0,4,0]$
 
-padicsum(h1,h2,5);
+padic_sum(h1,h2,5);
 [[0],4,2,2,2,2,2,2,2,2]$
 
-padicsubstract(h1,h2,5);
+padic_subtract(h1,h2,5);
 [[0],4,0,4,0,4,0,4,0,4]$
 
-padicsubstract(hensel(3/4,5,4),hensel(3/2,5,4),5);
+padic_subtract(hensel(3/4,5,4),hensel(3/2,5,4),5);
 [[0],3,3,3,3]$
 
 t1:hensel(4/15,5,4);
@@ -202,10 +202,10 @@ t1:hensel(4/15,5,4);
 t2:hensel(5/2,5,4);
 [[1],3,2,2,2]$
 
-padicmult(t1,t2,5);
+padic_multiply(t1,t2,5);
 [[0],4,1,3,1]$
 
-padicmult(h1,h2,5);
+padic_multiply(h1,h2,5);
 [[1],4,2,0,1,2,4,3,2,0]$
 
 al:hensel(1/4,5,4);
@@ -214,13 +214,13 @@ al:hensel(1/4,5,4);
 be:hensel(1/3,5,4);
 [[0],2,3,1,3]$
 
-padicmult(al,be,5);
+padic_multiply(al,be,5);
 [[0],3,4,2,4]$
 
-normalhensel([[-1],0,0,1,2,3]);
+normalize_hensel([[-1],0,0,1,2,3]);
 [[1],1,2,3]$
 
-padicdiv([[0],4,0,0,0,0,0,0],[[0],2,0,0,0,0,0,0],7);
+padic_divide([[0],4,0,0,0,0,0,0],[[0],2,0,0,0,0,0,0],7);
 [[0],2,0,0,0,0,0,0]$
 
 dividend:[[0],4,1,3,1,3,1,3];
@@ -229,7 +229,7 @@ dividend:[[0],4,1,3,1,3,1,3];
 divisor:[[0],3,4,2,4,2,4,2];
 [[0],3,4,2,4,2,4,2]$
 
-padicdivi(dividend,divisor,5);
+padic_dividei(dividend,divisor,5);
 [[0],3,1,0,0,0,0,0]$
 
 d1:[[0],2,1,1,1];
@@ -238,13 +238,13 @@ d1:[[0],2,1,1,1];
 d2:[[-1],1,1,0,0];
 [[-1],1,1,0,0]$
 
-padicdiv(d1,d2,5);
+padic_divide(d1,d2,5);
 [[1],2,4,1,4]$
 
-padicdiv([[0],4,3,3,3],[[0],0,1,4,0],5);
+padic_divide([[0],4,3,3,3],[[0],0,1,4,0],5);
 [[-2],0,4,2,2]$
 
-padicsum(padicdiv([[0],4,3,3,3],padicsum([[0],3,2,2,2],[[0],2,3,1,3],5),5),[[-2],1,0,0,0],5);
+padic_sum(padic_divide([[0],4,3,3,3],padic_sum([[0],3,2,2,2],[[0],2,3,1,3],5),5),[[-2],1,0,0,0],5);
 [[-2],1,4,2,2]$
 
 alf:hensel(8/9,5,4);
@@ -253,7 +253,7 @@ alf:hensel(8/9,5,4);
 bet:hensel(1/2,5,4);
 [[0],3,2,2,2]$
 
-padicdiv(alf,bet,5);
+padic_divide(alf,bet,5);
 [[0],4,4,3,2]$
 
 hensel(1/333333,5,27);
@@ -264,61 +264,61 @@ hensel(1/333333,5,27);
 farey(17);
 [0,1/17,1/16,1/15,1/14,1/13,1/12,1/11,1/10,1/9,2/17,1/8,2/15,1/7,2/13,1/6,3/17,2/11,3/16,1/5,3/14,2/9,3/13,4/17,1/4,4/15,3/11,2/7,5/17,3/10,4/13,5/16,1/3,6/17,5/14,4/11,3/8,5/13,2/5,7/17,5/12,3/7,7/16,4/9,5/11,6/13,7/15,8/17,1/2,9/17,8/15,7/13,6/11,5/9,9/16,4/7,7/12,10/17,3/5,8/13,5/8,7/11,9/14,11/17,2/3,11/16,9/13,7/10,12/17,5/7,8/11,11/15,3/4,13/17,10/13,7/9,11/14,4/5,13/16,9/11,14/17,5/6,11/13,6/7,13/15,7/8,15/17,8/9,9/10,10/11,11/12,12/13,13/14,14/15,15/16,16/17,1]$
 
-henseltofarey([[2],3,0,0,0,0,0,0,0],7);
+hensel_to_farey([[2],3,0,0,0,0,0,0,0],7);
 147$
 
-henseltofarey([[0],4,4,4,4,4,4,4],5);
+hensel_to_farey([[0],4,4,4,4,4,4,4],5);
 -1$
 
-henseltofarey([[0],3,3,3,3,3,3,3],5);
+hensel_to_farey([[0],3,3,3,3,3,3,3],5);
 -3/4$
 
-henseltofarey([[0],0,0,0,0,0,0],5);
+hensel_to_farey([[0],0,0,0,0,0,0],5);
 0$
 
-henseltofarey([[0],2,3,1,5],7);
+hensel_to_farey([[0],2,3,1,5],7);
 9/43$
 
-henseltofarey([[0],0,2,4,1],5);
+hensel_to_farey([[0],0,2,4,1],5);
 5/8$
 
-henseltofarey([[1],2,4,1,4],5);
+hensel_to_farey([[1],2,4,1,4],5);
 5/8$
 
-henseltofarey([[-1],3,2,2,2],5);
+hensel_to_farey([[-1],3,2,2,2],5);
 1/10$
 
-henseltofarey([[0],3,2,2,2],5);
+hensel_to_farey([[0],3,2,2,2],5);
 1/2$
 
-henseltofarey([[0],2,3,1,3],5);
+hensel_to_farey([[0],2,3,1,3],5);
 1/3$
 
-henseltofarey([[0],0,6,0,6],7);
+hensel_to_farey([[0],0,6,0,6],7);
 -7/8$
 
-henseltofarey([[0],2,2,1,0],5);
+hensel_to_farey([[0],2,2,1,0],5);
 4/17$
 
-henseltofarey([[0],1,2,1,4],5);
+hensel_to_farey([[0],1,2,1,4],5);
 2/7$
 
-henseltofarey([[0],2,2,1,0],5);
+hensel_to_farey([[0],2,2,1,0],5);
 4/17$
 
-henseltofarey([[0],2,2,3,4],5);
+hensel_to_farey([[0],2,2,3,4],5);
 17/16$
 
-henseltofarey([[0],4,2,3,4],5);
+hensel_to_farey([[0],4,2,3,4],5);
 13/17$
 
-henseltofarey([[0],1,1,0,0,1,0],3);
+hensel_to_farey([[0],1,1,0,0,1,0],3);
 -13/17$
 
-henseltofarey([[0],1,2,1,4],5);
+hensel_to_farey([[0],1,2,1,4],5);
 2/7$
 
-henseltofarey([[0],3,4,2,3],5);
+hensel_to_farey([[0],3,4,2,3],5);
 11/7$
 
 /* Hensel codes of square roots */
@@ -329,46 +329,46 @@ sqrtmod(2,5);
 sqrtmod(2,7);
 [3,4]$
 
-padicsqrt(2,7);
+padic_sqrt(2,7);
 [215912063945802350977/152672884556058511392,2267891697076964737/1603641597827614272]$
 
 map(lambda([u],hensel(u,7,9)),%);
 [[[0],3,1,2,6,1,2,1,2,4],[[0],4,5,4,0,5,4,5,4,2]]$
 
-padicsqrt(7,3,3);
+padic_sqrt(7,3,3);
 [977/368,108497/41008]$
 
 map(lambda([u],hensel(u,3,6)),%);
 [[[0],1,1,1,0,2,0],[[0],2,1,1,2,0,2]]$
 
-henseltofarey(%[1],3);
+hensel_to_farey(%[1],3);
 1/25$
 
-padicsqrt(6,5)[1];
+padic_sqrt(6,5)[1];
 80746825394092993/32964753427463648$
 
 hensel(%,5,4);
 [[0],1,3,0,4]$
 
-padicsqrt(25,7);
+padic_sqrt(25,7);
 [552213837122886833247075521/110442767424206762611644736,5]$
 
 map(lambda([u],hensel(u,7,8)),%);
 [[[0],2,6,6,6,6,6,6,6],[[0],5,0,0,0,0,0,0,0]]$
 
-padicsqrt(-2,3);
+padic_sqrt(-2,3);
 [-28545857/22783264,28545857/22783264]$
 
 hensel(%[1],3,8);
 [[0],1,1,2,0,0,2,0,1]$
 
-padicsqrt(1,3,3);
+padic_sqrt(1,3,3);
 [1,3281/3280]$
 
 map(lambda([u],hensel(u,3,8)),%);
 [[[0],1,0,0,0,0,0,0,0],[[0],2,2,2,2,2,2,2,2]]$
 
-map(lambda([u],henseltofarey(u,3)),%);
+map(lambda([u],hensel_to_farey(u,3)),%);
 [1,-1]$
 
 (remvalue(l1,l2,h1,h2,t1,t2,al,be,dividend,divisor,d1,d2,alf,bet),remarray(h),0);


### PR DESCRIPTION
This pull request renames all functions padicfoo to padic_foo, and makes other name changes in a similar spirit. The function definitions in padics.mac are changed by this PR, and the same name changes are applied to rtest_padics.mac and padics-doc.tex. There are a few other minor changes.

When I run `batch("rtest_padics.mac", test)`, all tests produce the expected output (same as before the changes were made).

I didn't update padics-doc.pdf in this PR. When I run `latex padics-doc.tex`, I get errors about bounding box sizes in the thumbnail JPEG files. Also, when I run `dvipdfm padics-doc`, I get a lot of errors, although it does produce a PDF file which seems to be OK. If there is a specific way to generate the PDF that is assumed, maybe the command or commands for that can be stated in the readme file or something.